### PR TITLE
Output cert meta serial number in hex.

### DIFF
--- a/cmd/hvclient/counters_stats.go
+++ b/cmd/hvclient/counters_stats.go
@@ -97,7 +97,7 @@ func outputCertsMeta(metas []hvclient.CertMeta, count int64, err error) {
 		fmt.Printf("%d\n", count)
 	} else {
 		for _, meta := range metas {
-			fmt.Printf("%s,%v,%v\n", meta.SerialNumber, meta.NotBefore, meta.NotAfter)
+			fmt.Printf("%x,%v,%v\n", meta.SerialNumber, meta.NotBefore, meta.NotAfter)
 		}
 	}
 }


### PR DESCRIPTION
Fix output routines to format serial number as hex, to match the required format of the endpoints which take it as input.