### PR TITLE
Feature/revocation reasons

### DIFF
--- a/client_api.go
+++ b/client_api.go
@@ -72,12 +72,14 @@ type SOAResults struct {
 // revoked when requesting revocation.
 type RevocationReason string
 
+// Revocation reasons to provide when revoking a certificate and providing a
+// reason for its revocation.
 const (
-	revocationReasonUnspecified          = "unspecified"
-	revocationReasonKeyCompromise        = "keyCompromise"
-	revocationReasonAffiliationChanged   = "affiliationChanged"
-	revocationReasonCessationOfOperation = "cessationOfOperation"
-	revocationReasonSuperseded           = "superseded"
+	RevocationReasonUnspecified          = "unspecified"
+	RevocationReasonKeyCompromise        = "keyCompromise"
+	RevocationReasonAffiliationChanged   = "affiliationChanged"
+	RevocationReasonCessationOfOperation = "cessationOfOperation"
+	RevocationReasonSuperseded           = "superseded"
 )
 
 const (

--- a/client_api.go
+++ b/client_api.go
@@ -172,7 +172,7 @@ func (c *Client) CertificateRevoke(
 	ctx context.Context,
 	serial *big.Int,
 ) error {
-	return c.CertificateRevokeWithReason(ctx, serial, revocationReasonUnspecified)
+	return c.CertificateRevokeWithReason(ctx, serial, RevocationReasonUnspecified)
 }
 
 // CertificateRevokeWithReason revokes a certificate with a specified reason.
@@ -186,7 +186,7 @@ func (c *Client) CertificateRevokeWithReason(
 	}
 
 	var patch = certificatePatch{
-		RevocationReason: revocationReasonUnspecified,
+		RevocationReason: RevocationReasonUnspecified,
 	}
 
 	var _, err = c.makeRequest(

--- a/client_api.go
+++ b/client_api.go
@@ -181,12 +181,10 @@ func (c *Client) CertificateRevokeWithReason(
 ) error {
 	type certificatePatch struct {
 		RevocationReason RevocationReason `json:"revocation_reason"`
-		RevocationTime   int64            `json:"revocation_time"`
 	}
 
 	var patch = certificatePatch{
 		RevocationReason: revocationReasonUnspecified,
-		RevocationTime:   0, // A value of 0 is ignored and the server will just use the current time
 	}
 
 	var _, err = c.makeRequest(

--- a/client_api.go
+++ b/client_api.go
@@ -75,11 +75,11 @@ type RevocationReason string
 // Revocation reasons to provide when revoking a certificate and providing a
 // reason for its revocation.
 const (
-	RevocationReasonUnspecified          = "unspecified"
-	RevocationReasonKeyCompromise        = "keyCompromise"
-	RevocationReasonAffiliationChanged   = "affiliationChanged"
-	RevocationReasonCessationOfOperation = "cessationOfOperation"
-	RevocationReasonSuperseded           = "superseded"
+	RevocationReasonUnspecified          = RevocationReason("unspecified")
+	RevocationReasonKeyCompromise        = RevocationReason("keyCompromise")
+	RevocationReasonAffiliationChanged   = RevocationReason("affiliationChanged")
+	RevocationReasonCessationOfOperation = RevocationReason("cessationOfOperation")
+	RevocationReasonSuperseded           = RevocationReason("superseded")
 )
 
 const (
@@ -186,7 +186,7 @@ func (c *Client) CertificateRevokeWithReason(
 	}
 
 	var patch = certificatePatch{
-		RevocationReason: RevocationReasonUnspecified,
+		RevocationReason: reason,
 	}
 
 	var _, err = c.makeRequest(

--- a/client_mock_test.go
+++ b/client_mock_test.go
@@ -276,12 +276,14 @@ func TestClientMockCertificatesRevokeWithReason(t *testing.T) {
 		name   string
 		serial *big.Int
 		reason hvclient.RevocationReason
+		time   int64
 		err    error
 	}{
 		{
 			name:   "OK",
 			serial: big.NewInt(0x741daf9ec2d5f7dc),
 			reason: hvclient.RevocationReasonUnspecified,
+			time:   0,
 		},
 		{
 			name:   "NotFound",
@@ -302,7 +304,7 @@ func TestClientMockCertificatesRevokeWithReason(t *testing.T) {
 			var ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
 
-			var err = client.CertificateRevokeWithReason(ctx, tc.serial, tc.reason)
+			var err = client.CertificateRevokeWithReason(ctx, tc.serial, tc.reason, tc.time)
 			if (err == nil) != (tc.err == nil) {
 				t.Fatalf("got error %v, want %v", err, tc.err)
 			}

--- a/client_mock_test.go
+++ b/client_mock_test.go
@@ -284,11 +284,6 @@ func TestClientMockCertificatesRevokeWithReason(t *testing.T) {
 			reason: "unspecified",
 		},
 		{
-			name:   "Not a valid reason",
-			serial: big.NewInt(0x741daf9ec2d5f7dc),
-			reason: "not a reason",
-		},
-		{
 			name:   "NotFound",
 			serial: mockBigIntNotFound,
 			err:    hvclient.APIError{StatusCode: http.StatusNotFound},

--- a/client_mock_test.go
+++ b/client_mock_test.go
@@ -281,7 +281,7 @@ func TestClientMockCertificatesRevokeWithReason(t *testing.T) {
 		{
 			name:   "OK",
 			serial: big.NewInt(0x741daf9ec2d5f7dc),
-			reason: "unspecified",
+			reason: hvclient.RevocationReasonUnspecified,
 		},
 		{
 			name:   "NotFound",


### PR DESCRIPTION
This PR adds support for the new revocation reasons PATCH endpoint and removes usage of the old revocation endpoint  which used the DELETE method. Tested this functionality manually with HVCA locally. This PR adds a new function to the hvclient library API named `CertificateRevokeWithReason` which is similar to the original `CertificateRevoke` but allows specifying of a reason code. The original `CertificateRevoke` function has been updated to use the new endpoint as well, but will always send a reason code of "unspecified".