### PR TITLE
Add SerialNumber to certificate request to frontend API

### DIFF
--- a/cmd/hvclient/flags.go
+++ b/cmd/hvclient/flags.go
@@ -59,6 +59,7 @@ var (
 // Subject distinguished name flags.
 var (
 	fSubjectCommonName         = flag.String("commonname", "", "subject common name")
+	fSubjectSerialNumber       = flag.String("serialnumber", "", "subject serial number")
 	fSubjectOrganization       = flag.String("organization", "", "subject organization")
 	fSubjectOrganizationalUnit = flag.String("organizationalunit", "", "comma-separated list of subject organizational unit(s)")
 	fSubjectStreetAddress      = flag.String("streetaddress", "", "subject street address")

--- a/cmd/hvclient/help.go
+++ b/cmd/hvclient/help.go
@@ -86,6 +86,7 @@ Certificate request options:
     At least one of these options should normally be selected.
 
     -commonname=<string>          Subject distinguished name (DN) common name
+    -serialnumber=<string>        Subject DN serial number
     -organization=<string>        Subject DN organization
     -organizationalunit=<string>  Comma-separated list of subject DN
                                   organizational units

--- a/cmd/hvclient/request_builders.go
+++ b/cmd/hvclient/request_builders.go
@@ -53,6 +53,7 @@ type validityValues struct {
 // specified at the command line for ease of passing to functions.
 type subjectValues struct {
 	commonName         string
+	serialNumber       string
 	organization       string
 	organizationalUnit string
 	streetAddress      string
@@ -78,6 +79,7 @@ type sanValues struct {
 func (s subjectValues) isEmpty() bool {
 	return checkAllEmpty(
 		s.commonName,
+		s.serialNumber,
 		s.organization,
 		s.organizationalUnit,
 		s.streetAddress,
@@ -297,6 +299,7 @@ func buildDN(dn *hvclient.DN, values subjectValues) (*hvclient.DN, error) {
 		from string
 		to   *string
 	}{
+		{values.serialNumber, &dn.SerialNumber},
 		{values.commonName, &dn.CommonName},
 		{values.organization, &dn.Organization},
 		{values.streetAddress, &dn.StreetAddress},

--- a/cmd/hvclient/request_cert.go
+++ b/cmd/hvclient/request_cert.go
@@ -40,6 +40,7 @@ func requestCert(clnt *hvclient.Client) error {
 			},
 			subject: subjectValues{
 				commonName:         *fSubjectCommonName,
+				serialNumber:       *fSubjectSerialNumber,
 				organization:       *fSubjectOrganization,
 				organizationalUnit: *fSubjectOrganizationalUnit,
 				streetAddress:      *fSubjectStreetAddress,

--- a/request.go
+++ b/request.go
@@ -615,7 +615,7 @@ func (n *DN) PKIXName() pkix.Name {
 		SerialNumber: n.SerialNumber,
 	}
 
-	// Next copy over all fields that are single-value in n but are are
+	// Next copy over all fields that are single-value in n but are
 	// multi-value in pkix.Name.
 	for _, field := range []struct {
 		value    string

--- a/request.go
+++ b/request.go
@@ -609,13 +609,14 @@ func (n *DN) Equal(other *DN) bool {
 
 // PKIXName converts a subject distinguished name into a pkix.Name object.
 func (n *DN) PKIXName() pkix.Name {
-	// Initialize name with all single-value fields.
+	// Initialize name with all fields that are single-value in both structs.
 	var name = pkix.Name{
 		CommonName:   n.CommonName,
 		SerialNumber: n.SerialNumber,
 	}
 
-	// Copy across fields with single values.
+	// Next copy over all fields that are single-value in n but are are
+	// multi-value in pkix.Name.
 	for _, field := range []struct {
 		value    string
 		location *[]string

--- a/request.go
+++ b/request.go
@@ -96,6 +96,7 @@ type DN struct {
 	JOIState           string         `json:"jurisdiction_of_incorporation_state_or_province_name,omitempty"`
 	JOICountry         string         `json:"jurisdiction_of_incorporation_country_name,omitempty"`
 	BusinessCategory   string         `json:"business_category,omitempty"`
+	SerialNumber       string         `json:"serial_number,omitempty"`
 	ExtraAttributes    []OIDAndString `json:"extra_attributes,omitempty"`
 }
 
@@ -602,14 +603,16 @@ func (n *DN) Equal(other *DN) bool {
 		n.JOILocality == other.JOILocality &&
 		n.JOIState == other.JOIState &&
 		n.JOICountry == other.JOICountry &&
-		n.BusinessCategory == other.BusinessCategory
+		n.BusinessCategory == other.BusinessCategory &&
+		n.SerialNumber == other.SerialNumber
 }
 
 // PKIXName converts a subject distinguished name into a pkix.Name object.
 func (n *DN) PKIXName() pkix.Name {
-	// Initialize name with common name.
+	// Initialize name with all single-value fields.
 	var name = pkix.Name{
-		CommonName: n.CommonName,
+		CommonName:   n.CommonName,
+		SerialNumber: n.SerialNumber,
 	}
 
 	// Copy across fields with single values.

--- a/request.go
+++ b/request.go
@@ -91,12 +91,12 @@ type DN struct {
 	Organization       string         `json:"organization,omitempty"`
 	OrganizationalUnit []string       `json:"organizational_unit,omitempty"`
 	CommonName         string         `json:"common_name,omitempty"`
+	SerialNumber       string         `json:"serial_number,omitempty"`
 	Email              string         `json:"email,omitempty"`
 	JOILocality        string         `json:"jurisdiction_of_incorporation_locality_name,omitempty"`
 	JOIState           string         `json:"jurisdiction_of_incorporation_state_or_province_name,omitempty"`
 	JOICountry         string         `json:"jurisdiction_of_incorporation_country_name,omitempty"`
 	BusinessCategory   string         `json:"business_category,omitempty"`
-	SerialNumber       string         `json:"serial_number,omitempty"`
 	ExtraAttributes    []OIDAndString `json:"extra_attributes,omitempty"`
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -633,6 +633,19 @@ func TestRequestNotEqual(t *testing.T) {
 			},
 		},
 		{
+			name: "SubjectSerialNumber",
+			first: hvclient.Request{
+				Subject: &hvclient.DN{
+					SerialNumber: "a value",
+				},
+			},
+			second: hvclient.Request{
+				Subject: &hvclient.DN{
+					SerialNumber: "a different value",
+				},
+			},
+		},
+		{
 			name: "SubjectStreetAddress",
 			first: hvclient.Request{
 				Subject: &hvclient.DN{

--- a/request_test.go
+++ b/request_test.go
@@ -195,6 +195,7 @@ var testRequestFullRequest = hvclient.Request{
 	},
 	Subject: &hvclient.DN{
 		CommonName:    "John Doe",
+		SerialNumber:  "1",
 		Country:       "GB",
 		State:         "London",
 		Locality:      "London",

--- a/request_test.go
+++ b/request_test.go
@@ -102,6 +102,7 @@ const testRequestFullJSON = `{
             "Development"
         ],
         "common_name": "John Doe",
+        "serial_number": "1",
         "email": "john.doe@demo.hvca.globalsign.com",
         "jurisdiction_of_incorporation_locality_name": "London",
         "jurisdiction_of_incorporation_state_or_province_name": "London",


### PR DESCRIPTION
Adds the serial number field to outgoing HVCA requests so it doesn't get packed into the extra_attributes field.