### PR TITLE
Custom clm

### DIFF
--- a/client_api.go
+++ b/client_api.go
@@ -178,7 +178,7 @@ func (c *Client) CertificateRekey(ctx context.Context, req *CertificateRekeyRequ
 		nil,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to reissue certificate: %w", err)
+		return nil, err
 	}
 	var snString string
 	snString, err = headerFromResponse(r, certSNHeaderName)

--- a/client_api.go
+++ b/client_api.go
@@ -113,6 +113,7 @@ const (
 	pathDNS                             = "/dns"
 	pathHTTP                            = "/http"
 	pathEmail                           = "/email"
+	pathRekey                           = "/rekey"
 )
 
 // CertificateRequest requests a new certificate based. The HVCA API is
@@ -162,6 +163,29 @@ func (c *Client) CertificateRetrieve(
 	}
 
 	return &r, nil
+}
+
+// CertificateRekey Submits a rekey request for an existing ISSUED certificate.The HVCA API is
+// asynchronous, and on success this method returns the serial number of
+// the new certificate. After a short delay, the certificate itself may be
+// retrieved via the CertificateRetrieve method.
+func (c *Client) CertificateRekey(ctx context.Context, req *CertificateRekeyRequest, id string) (*string, error) {
+	var r, err = c.makeRequest(
+		ctx,
+		endpointCertificates+"/"+url.QueryEscape(id)+pathRekey,
+		http.MethodPost,
+		req,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reissue certificate: %w", err)
+	}
+	var snString string
+	snString, err = headerFromResponse(r, certSNHeaderName)
+	if err != nil {
+		return nil, err
+	}
+	return &snString, nil
 }
 
 // CertificateRevoke revokes a certificate.

--- a/cmd/hvclient/certs.go
+++ b/cmd/hvclient/certs.go
@@ -125,6 +125,7 @@ func rekeyCert(clnt *hvclient.Client, serialNumber string) error {
 
 	var sn *string
 	if sn, err = clnt.CertificateRekey(ctx, req, serialNumber); err != nil {
+		fmt.Println(err)
 		return fmt.Errorf("couldn't obtain certificate: %v", err)
 	}
 

--- a/cmd/hvclient/flags.go
+++ b/cmd/hvclient/flags.go
@@ -106,6 +106,7 @@ var (
 	fStatus   = flag.String("status", "", "show the status of the certificate with the specified serial number")
 	fUpdated  = flag.String("updated", "", "show the updated-at time for the certificate with the specified serial number")
 	fRevoke   = flag.String("revoke", "", "revoke the certificate with the specified serial number")
+	fRekey    = flag.String("rekey", "", "rekey the certificate with the specified serial number")
 )
 
 // Account statistics and information flags.

--- a/cmd/hvclient/help.go
+++ b/cmd/hvclient/help.go
@@ -125,6 +125,7 @@ Certificate and account information options:
   -retrieve=<serial>    Retrieve the previously-issued certificate with the
                         specified serial number
   -revoke=<serial>      Revoke the certificate with the specified serial number
+  -rekey=<serial>       Reissue the certificate with the specified serial number
   -status=<serial>      Show the issued/revoked status for the certificate with
                         the specified serial number
   -updated=<serial>     Show the last-updated time for the certificate with the

--- a/cmd/hvclient/main.go
+++ b/cmd/hvclient/main.go
@@ -111,7 +111,7 @@ func main() {
 	timeout = clnt.DefaultTimeout()
 
 	// Select and execute desired operation.
-	var willRequest = !(*fPublicKey == "" && *fPrivateKey == "" && *fCSR == "")
+	var willRequest = (!(*fPublicKey == "" && *fPrivateKey == "" && *fCSR == "") && (*fRekey == ""))
 
 	switch {
 	case willRequest:
@@ -121,6 +121,9 @@ func main() {
 
 	case *fRetrieve != "":
 		retrieveCert(clnt, *fRetrieve)
+
+	case *fRekey != "":
+		rekeyCert(clnt, *fRekey)
 
 	case *fRevoke != "":
 		revokeCert(clnt, *fRevoke)

--- a/request.go
+++ b/request.go
@@ -65,7 +65,14 @@ type Request struct {
 	CSR                 *x509.CertificateRequest
 	Signature           *Signature
 	PrivateKey          interface{}
-	PublicKey           string
+	PublicKey           interface{}
+}
+
+// CertificateRekeyRequest is a request to HVCA to reissue a certificate.
+type CertificateRekeyRequest struct {
+	Signature          *Signature `json:"signature"`
+	PublicKey          string     `json:"public_key"`
+	PublicKeySignature string     `json:"public_key_signature"`
 }
 
 // Validity contains the requested not-before and not-after times for a
@@ -166,7 +173,7 @@ type jsonRequest struct {
 	MSExtension         *MSExtension         `json:"ms_extension_template,omitempty"`
 	CustomExtensions    json.RawMessage      `json:"custom_extensions,omitempty"`
 	Signature           *Signature           `json:"signature,omitempty"`
-	PublicKey           string               `json:"public_key,omitempty"`
+	PublicKey           interface{}          `json:"public_key,omitempty"`
 	PublicKeySignature  string               `json:"public_key_signature,omitempty"`
 }
 


### PR DESCRIPTION
#### Description
update hvclient with changes for rekey and its command line related changes to accept rekey flag
 
#### Solution and config changes
major changes in the PR are as follows- 
client_api.go file is added with a new function "CertificateRekey" to facilitate rekey to hit HV and get the new reissued certificate serial in location header
certs.go file is added with the "rekeyCert" function which will get triggered when rekey flag is passed in command line.
Rest of the changes are made to resolve errors which were already present in the custom_clm branch.