### PR TITLE
SAN Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,19 @@ Creating a `Client` object requires:
 1. An API key and API secret provided by GlobalSign during account set-up; and
 
 2. A private key and a certificate to use for mutual TLS authentication
-with the HVCA server. The private key should be the one associated with
-the public key that was provided to GlobalSign during account set-up, and
-the certificate should be the one provided by GlobalSign along with the API
-key and API secret.
+   with the HVCA server. The private key should be the one associated with
+   the public key that was provided to GlobalSign during account set-up, and
+   the certificate should be the one provided by GlobalSign along with the API
+   key and API secret.
 
 The `Client` object may be created with either:
 
 1. A [configuration file](#configuration-file), useful when the account credentials are located in
-files; or with
+   files; or with
 
 2. A `Config` object, useful when the account credentials are obtained
-programmatically from a secrets vault, from environment variables, or in some
-other manner.
+   programmatically from a secrets vault, from environment variables, or in some
+   other manner.
 
 ## Configuration file
 
@@ -62,16 +62,17 @@ An example configuration file:
 }
 ```
 
-* `key_passphrase` must be provided if the mTLS private key is an encrypted
-PEM block as specified in RFC 1423.
-* `insecure_skip_verify` controls whether the client verifies the server's
-certificate chain and host name. If true, any certificate presented by the
-server and any host name in that certificate is accepted. In this mode, TLS
-is susceptible to machine-in-the-middle attacks unless custom verification
-is used. This should be used only for testing.
-* `extra_headers` are optional additional HTTP headers to include in the
-requests to the server.
-* `timeout` specifies a request timeout in seconds.
+- `key_passphrase` must be provided if the mTLS private key is an encrypted
+  PEM block as specified in RFC 1423.
+- `insecure_skip_verify` controls whether the client verifies the server's
+  certificate chain and host name. If true, any certificate presented by the
+  server and any host name in that certificate is accepted. In this mode, TLS
+  is susceptible to machine-in-the-middle attacks unless custom verification
+  is used. This should be used only for testing.
+- `extra_headers` are optional additional HTTP headers to include in the
+  requests to the server.
+- `timeout` specifies a request timeout in seconds.
 
 ## Demo
+
 [![asciicast](https://asciinema.org/a/P6MSC1Qqe78GYWsiucs5DAM8B.svg)](https://asciinema.org/a/P6MSC1Qqe78GYWsiucs5DAM8B)

--- a/api_error.go
+++ b/api_error.go
@@ -25,19 +25,21 @@ import (
 )
 
 // APIError is an error returned by the HVCA HTTP API.
-type APIError struct {
+type APIError 	struct {
 	StatusCode  int
 	Description string
+	Errors      map[string]string // Additional error details
 }
 
 // hvcaError is the format of an HVCA error HTTP response body.
 type hvcaError struct {
-	Description string `json:"description"`
+	Description string 		 		`json:"description"`
+	Errors 		map[string]string 	`json:"errors,omitempty"`
 }
 
 // Error returns a string representation of the error.
 func (e APIError) Error() string {
-	return fmt.Sprintf("%d: %s", e.StatusCode, e.Description)
+	return fmt.Sprintf("%d: %s %s", e.StatusCode, e.Description, e.Errors)
 }
 
 // NewAPIError creates a new APIError object from an HTTP response.
@@ -63,5 +65,5 @@ func NewAPIError(r *http.Response) APIError {
 		return APIError{StatusCode: r.StatusCode, Description: "unknown API error"}
 	}
 
-	return APIError{StatusCode: r.StatusCode, Description: hvErr.Description}
+	return APIError{StatusCode: r.StatusCode, Description: hvErr.Description, Errors: hvErr.Errors}
 }

--- a/api_error_test.go
+++ b/api_error_test.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/globalsign/hvclient/internal/httputils"
+	"github.com/google/go-cmp/cmp"
 )
 
 // errReader implements io.Reader and always returns an error.
@@ -72,7 +72,7 @@ func TestAPIError(t *testing.T) {
 			want: APIError{
 				StatusCode:  http.StatusBadRequest,
 				Description: "san: failed dns/email domain name verification",
-				Errors: map[string]string{"requires_label_separator": "dummy"},
+				Errors: &map[string]string{"requires_label_separator": "dummy"},
 			},
 		},
 		{

--- a/api_error_test.go
+++ b/api_error_test.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/globalsign/hvclient/internal/httputils"
 	"github.com/google/go-cmp/cmp"
+	"github.com/globalsign/hvclient/internal/httputils"
 )
 
 // errReader implements io.Reader and always returns an error.
@@ -53,6 +53,26 @@ func TestAPIError(t *testing.T) {
 			want: APIError{
 				StatusCode:  http.StatusBadRequest,
 				Description: "custom message",
+			},
+		},
+		{
+			name: "OKWithErrors",
+			in: &http.Response{
+				Body: ioutil.NopCloser(strings.NewReader(`{
+					"description": "san: failed dns/email domain name verification",
+					"errors": {
+						"requires_label_separator": "dummy"
+					}
+				}`)),
+				Header: http.Header{
+					httputils.ContentTypeHeader: []string{httputils.ContentTypeProblemJSON},
+				},
+				StatusCode: http.StatusBadRequest,
+			},
+			want: APIError{
+				StatusCode:  http.StatusBadRequest,
+				Description: "san: failed dns/email domain name verification",
+				Errors: map[string]string{"requires_label_separator": "dummy"},
 			},
 		},
 		{

--- a/client.go
+++ b/client.go
@@ -76,6 +76,7 @@ func (c *Client) makeRequest(
 	ctx context.Context,
 	path string,
 	method string,
+	headers map[string]string,
 	in interface{},
 	out interface{},
 ) (*http.Response, error) {
@@ -112,6 +113,11 @@ func (c *Client) makeRequest(
 			request.Header.Add(key, value)
 		}
 
+		// Add custom headers which are passed as arguments 
+		for key, value := range headers {
+			request.Header.Add(key, value)
+		}
+
 		// Perform specific processing for non-login requests.
 		if !strings.HasPrefix(path, endpointLogin) {
 			// Since this is not a login request, preemptively login again if
@@ -129,6 +135,7 @@ func (c *Client) makeRequest(
 		if response, err = c.HTTPClient.Do(request); err != nil {
 			return nil, fmt.Errorf("failed to execute HTTP request: %w", err)
 		}
+
 		defer httputils.ConsumeAndCloseResponseBody(response)
 
 		// HVCA doesn't return any 3XX HTTP status codes, so treat everything outside

--- a/client_api.go
+++ b/client_api.go
@@ -129,6 +129,7 @@ func (c *Client) CertificateRequest(
 		ctx,
 		endpointCertificates,
 		http.MethodPost,
+		nil,
 		req,
 		nil,
 	)
@@ -145,6 +146,27 @@ func (c *Client) CertificateRequest(
 	return &snString, nil
 }
 
+func (c *Client) ValidateSANs(
+	ctx context.Context,
+	req *Request,
+	headers map[string]string,
+) (*http.Response, error) {
+
+	var response, err = c.makeRequest(
+		ctx,
+		endpointCertificates,
+		http.MethodPost,
+		headers,
+		req,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
 // CertificateRetrieve retrieves a certificate.
 func (c *Client) CertificateRetrieve(
 	ctx context.Context,
@@ -155,6 +177,7 @@ func (c *Client) CertificateRetrieve(
 		ctx,
 		endpointCertificates+"/"+url.QueryEscape(fmt.Sprintf("%X", serial)),
 		http.MethodGet,
+		nil,
 		nil,
 		&r,
 	)
@@ -174,6 +197,7 @@ func (c *Client) CertificateRekey(ctx context.Context, req *CertificateRekeyRequ
 		ctx,
 		endpointCertificates+"/"+url.QueryEscape(id)+pathRekey,
 		http.MethodPost,
+		nil,
 		req,
 		nil,
 	)
@@ -227,6 +251,7 @@ func (c *Client) CertificateRevokeWithReason(
 		ctx,
 		endpointCertificates+"/"+url.QueryEscape(fmt.Sprintf("%X", serial)),
 		http.MethodPatch,
+		nil,
 		&patch,
 		nil,
 	)
@@ -242,6 +267,7 @@ func (c *Client) TrustChain(ctx context.Context) ([]*x509.Certificate, error) {
 		ctx,
 		endpointTrustChain,
 		http.MethodGet,
+		nil,
 		nil,
 		&chain,
 	)
@@ -277,6 +303,7 @@ func (c *Client) Policy(ctx context.Context) (*Policy, error) {
 		endpointPolicy,
 		http.MethodGet,
 		nil,
+		nil,
 		&pol,
 	)
 	if err != nil {
@@ -310,7 +337,7 @@ func (c *Client) countersCommon(
 	path string,
 ) (int64, error) {
 	var count counter
-	var _, err = c.makeRequest(ctx, path, http.MethodGet, nil, &count)
+	var _, err = c.makeRequest(ctx, path, http.MethodGet,nil, nil, &count)
 	if err != nil {
 		return 0, err
 	}
@@ -379,6 +406,7 @@ func (c *Client) statsCommon(
 		path+paginationString(page, perPage, from, to),
 		http.MethodGet,
 		nil,
+		nil,
 		&stats,
 	)
 	if err != nil {
@@ -419,6 +447,7 @@ func (c *Client) ClaimsDomains(
 		endpointClaimsDomains+queryParams,
 		http.MethodGet,
 		nil,
+		nil,
 		&claims,
 	)
 	if err != nil {
@@ -442,6 +471,7 @@ func (c *Client) ClaimSubmit(ctx context.Context, domain string) (*ClaimAssertio
 		ctx,
 		endpointClaimsDomains+"/"+url.QueryEscape(domain),
 		http.MethodPost,
+		nil,
 		nil,
 		&info,
 	)
@@ -468,6 +498,7 @@ func (c *Client) ClaimRetrieve(ctx context.Context, id string) (*Claim, error) {
 		endpointClaimsDomains+"/"+url.QueryEscape(id),
 		http.MethodGet,
 		nil,
+		nil,
 		&claim,
 	)
 	if err != nil {
@@ -483,6 +514,7 @@ func (c *Client) ClaimDelete(ctx context.Context, id string) error {
 		ctx,
 		endpointClaimsDomains+"/"+url.QueryEscape(id),
 		http.MethodDelete,
+		nil,
 		nil,
 		nil,
 	)
@@ -543,6 +575,7 @@ func (c *Client) ClaimEmailRetrieve(ctx context.Context, id string) (*Authorised
 		endpointClaimsDomains+"/"+url.QueryEscape(id)+pathEmail,
 		http.MethodGet,
 		nil,
+		nil,
 		&authorisedEmails,
 	)
 	if err != nil {
@@ -566,6 +599,7 @@ func (c *Client) ClaimReassert(ctx context.Context, id string) (*ClaimAssertionI
 		endpointClaimsDomains+"/"+url.QueryEscape(id)+pathReassert,
 		http.MethodPost,
 		nil,
+		nil,
 		&info,
 	)
 	if err != nil {
@@ -588,6 +622,7 @@ func (c *Client) claimAssert(ctx context.Context, body interface{}, id, path str
 		ctx,
 		endpointClaimsDomains+"/"+url.QueryEscape(id)+path,
 		http.MethodPost,
+		nil,
 		body,
 		nil,
 	)
@@ -612,6 +647,7 @@ func (c *Client) ClaimADNRetrieve(ctx context.Context, id string) ([]string, err
 		ctx,
 		endpointClaimsDomains+"/"+url.QueryEscape(id)+pathDNS,
 		http.MethodGet,
+		nil,
 		nil,
 		&adns,
 	)

--- a/client_api.go
+++ b/client_api.go
@@ -146,6 +146,8 @@ func (c *Client) CertificateRequest(
 	return &snString, nil
 }
 
+// ValidateSANs validates a set of Subject Alternative Names (SANs) within
+// a certificate request. On success this method returns an 204 HTTP response.
 func (c *Client) ValidateSANs(
 	ctx context.Context,
 	req *Request,

--- a/client_login.go
+++ b/client_login.go
@@ -59,6 +59,7 @@ func (c *Client) login(ctx context.Context) error {
 		ctx,
 		endpointLogin,
 		http.MethodPost,
+		nil,
 		req,
 		&resp,
 	)

--- a/client_mock_test.go
+++ b/client_mock_test.go
@@ -18,15 +18,14 @@ package hvclient_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/big"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/globalsign/hvclient"
 	"github.com/globalsign/hvclient/internal/pki"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestClientMockNew(t *testing.T) {
@@ -110,13 +109,13 @@ func TestClientMockCertificatesRequest(t *testing.T) {
 	var testcases = []struct {
 		name string
 		cn   string
-		want *big.Int
+		want string
 		err  error
 	}{
 		{
 			name: "OK",
 			cn:   "John Doe",
-			want: mustParseBigInt(t, mockCertSerial, 16),
+			want: mockCertSerialLocation,
 		},
 		{
 			name: "TriggeredError",
@@ -163,8 +162,8 @@ func TestClientMockCertificatesRequest(t *testing.T) {
 				return
 			}
 
-			if fmt.Sprintf("%X", got) != mockCertSerial {
-				t.Fatalf("got %X, want %s", got, mockCertSerial)
+			if *got != tc.want {
+				t.Fatalf("got %s, want %s", *got, tc.want)
 			}
 		})
 	}

--- a/cmd/hvclient/helpers_test.go
+++ b/cmd/hvclient/helpers_test.go
@@ -22,9 +22,9 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/globalsign/hvclient"
 	"github.com/globalsign/hvclient/internal/testhelpers"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestCheckOneValue(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,8 +19,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/globalsign/hvclient/internal/config"
 	"github.com/google/go-cmp/cmp"
+	"github.com/globalsign/hvclient/internal/config"
 )
 
 func TestConfigNewFromFile(t *testing.T) {

--- a/mock_hvca_test.go
+++ b/mock_hvca_test.go
@@ -27,10 +27,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi"
 	"github.com/globalsign/hvclient"
 	"github.com/globalsign/hvclient/internal/httputils"
 	"github.com/globalsign/hvclient/internal/pki"
-	"github.com/go-chi/chi"
 )
 
 // Note: mocking up the entire HVCA API service seems a little extreme, and
@@ -133,6 +133,7 @@ const (
 	mockAPIKey              = "mock_api_key"
 	mockAPISecret           = "mock_api_secret"
 	mockCertSerial          = "741DAF9EC2D5F7DC"
+	mockCertSerialLocation  = "http://local/certificates/741DAF9EC2D5F7DC"
 	mockCounterIssued       = 72
 	mockCounterRevoked      = 14
 	mockClaimDomainVerified = "verified.com."

--- a/policy_test.go
+++ b/policy_test.go
@@ -22,8 +22,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/globalsign/hvclient"
 	"github.com/google/go-cmp/cmp"
+	"github.com/globalsign/hvclient"
 )
 
 var testPolicyFullJSON = `{


### PR DESCRIPTION
Added a new method to validate SANs before the actual certificate is issued.
Updated Mocktests and Integration tests.
Updated makerequest function to accept custom headers.
Updated the error structs to receive all fields from HV and send all fields back to the calling function.