### PR TITLE
Updated the method name for Cert request validation

### DIFF
--- a/client_api.go
+++ b/client_api.go
@@ -146,9 +146,9 @@ func (c *Client) CertificateRequest(
 	return &snString, nil
 }
 
-// ValidateSANs validates a set of Subject Alternative Names (SANs) within
-// a certificate request. On success this method returns an 204 HTTP response.
-func (c *Client) ValidateSANs(
+// ValidateCertificateRequest validates the certificate issuance request payload. 
+// On success this method returns an 204 HTTP response, but does not issue the certificate.
+func (c *Client) ValidateCertificateRequest(
 	ctx context.Context,
 	req *Request,
 	headers map[string]string,

--- a/client_int_test.go
+++ b/client_int_test.go
@@ -163,13 +163,13 @@ func TestCertificates(t *testing.T) {
 			for i := range certs {
 				req.Validity.NotBefore = time.Now()
 
-				// Validate SANs.
-				headers := map[string]string{"mode": "domain-validation"}
+			// Validate certificate request.
+			headers := map[string]string{"mode": "domain-validation"}
 
-				httpResponse, err := client.ValidateSANs(ctx, req, headers)
-				if err != nil || httpResponse.StatusCode != 204{
-					t.Fatalf("failed to validate SANs: %v", err)
-				}
+			httpResponse, err := client.ValidateCertificateRequest(ctx, req, headers)
+			if err != nil || httpResponse.StatusCode != 204 {
+				t.Fatalf("failed to validate Certificate request: %v", err)
+			}
 
 				// Request certificate.
 				var serialNumber *string


### PR DESCRIPTION
Updated the ValidateSANs method name to ValidateCertificateRequest since the dry-run mode is also included and it validates the entire payload, similar to that of issuance, and not just SANs.