### PR TITLE
Fix for DNS TXT and DNS CAA email records not showing when retrieving list of email addresses authorized to perform email validation

### DIFF
--- a/client_api.go
+++ b/client_api.go
@@ -58,12 +58,21 @@ type AuthorisedEmails struct {
 // DNSResults is a set of maps for all queried record types. Record types are the keys of the maps.
 type DNSResults struct {
 	SOA SOAResults `json:"SOA"`
-	// TXT is not supported
-	// CAA is not supported
+	TXT TXTResults `json:"TXT"`
+	CAA CAAResults `json:"CAA"`
 }
 
 // SOAResults is a map of SOA records for DNS results
-type SOAResults struct {
+type SOAResults DNSEmailResults
+
+// TXTResults is a map of TXT records for DNS results
+type TXTResults DNSEmailResults
+
+// CAAResults is a map of CAA records for DNS results
+type CAAResults DNSEmailResults
+
+// DNSEmailResults is a set of email addresses and errors for a DNS record type
+type DNSEmailResults struct {
 	Emails []string `json:"emails"`
 	Errors []string `json:"errors,omitempty"`
 }
@@ -146,7 +155,7 @@ func (c *Client) CertificateRequest(
 	return &snString, nil
 }
 
-// ValidateCertificateRequest validates the certificate issuance request payload. 
+// ValidateCertificateRequest validates the certificate issuance request payload.
 // On success this method returns an 204 HTTP response, but does not issue the certificate.
 func (c *Client) ValidateCertificateRequest(
 	ctx context.Context,
@@ -339,7 +348,7 @@ func (c *Client) countersCommon(
 	path string,
 ) (int64, error) {
 	var count counter
-	var _, err = c.makeRequest(ctx, path, http.MethodGet,nil, nil, &count)
+	var _, err = c.makeRequest(ctx, path, http.MethodGet, nil, nil, &count)
 	if err != nil {
 		return 0, err
 	}

--- a/client_api_test.go
+++ b/client_api_test.go
@@ -1,0 +1,237 @@
+package hvclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/globalsign/hvclient/internal/testhelpers"
+)
+
+// Mock response data from GlobalSign Atlas Certificate Management API.
+var mockResponse string = `{
+		"constructed": [
+			"admin@test.com",
+			"administrator@test.com",
+			"webmaster@test.com",
+			"hostmaster@test.com",
+			"postmaster@test.com"
+		],
+		"dns": {
+			"SOA": {
+				"emails": [
+					"SOAexample@test.com"
+				]
+			},
+			"TXT": {
+				"emails": [
+					"TXTexample@test.com"
+				]
+			},
+			"CAA": {
+				"emails": [
+					"CAAexample@test.com"
+				]
+			}
+		}
+	}`
+
+var mockResponseWithErrors string = `{
+		"constructed": [
+			"admin@test.com",
+			"administrator@test.com",
+			"webmaster@test.com",
+			"hostmaster@test.com",
+			"postmaster@test.com"
+		],
+		"dns": {
+			"SOA": {
+				"emails": [
+					"SOAexample@test.com"
+				],
+        "errors": [
+          "Sample SOA error message"
+        ]
+			},
+			"TXT": {
+				"emails": [
+					"TXTexample@test.com"
+				],
+        "errors": [
+          "Sample TXT error message"
+        ]
+			},
+			"CAA": {
+				"emails": [
+					"CAAexample@test.com"
+				],
+        "errors": [
+          "Sample CAA error message"
+        ]
+			}
+		}
+	}`
+
+var mockResponseTXTOnly string = `{
+		"constructed": [
+			"admin@test.com",
+			"administrator@test.com",
+			"webmaster@test.com",
+			"hostmaster@test.com",
+			"postmaster@test.com"
+		],
+		"dns": {
+      "SOA": {
+        "emails": []
+      },
+			"TXT": {
+				"emails": [
+					"TXTexample@test.com"
+				]
+			},
+      "CAA": {
+        "emails": []
+      }
+		}
+	}`
+
+func TestClaimEmailRetrieve(t *testing.T) {
+	var testcases = []struct {
+		name        string
+		apiResponse string
+
+		expectedResponse AuthorisedEmails
+	}{
+		{
+			name:        "Response received containing records for SOA, TXT, CAA",
+			apiResponse: mockResponse,
+
+			expectedResponse: AuthorisedEmails{
+				Constructed: []string{
+					"admin@test.com",
+					"administrator@test.com",
+					"webmaster@test.com",
+					"hostmaster@test.com",
+					"postmaster@test.com",
+				},
+				DNS: DNSResults{
+					SOA: SOAResults{
+						Emails: []string{
+							"SOAexample@test.com",
+						},
+					},
+					TXT: TXTResults{
+						Emails: []string{
+							"TXTexample@test.com",
+						},
+					},
+					CAA: CAAResults{
+						Emails: []string{
+							"CAAexample@test.com",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Response received containing records for SOA, TXT, CAA with errors",
+			apiResponse: mockResponseWithErrors,
+
+			expectedResponse: AuthorisedEmails{
+				Constructed: []string{
+					"admin@test.com",
+					"administrator@test.com",
+					"webmaster@test.com",
+					"hostmaster@test.com",
+					"postmaster@test.com",
+				},
+				DNS: DNSResults{
+					SOA: SOAResults{
+						Emails: []string{
+							"SOAexample@test.com",
+						},
+						Errors: []string{
+							"Sample SOA error message",
+						},
+					},
+					TXT: TXTResults{
+						Emails: []string{
+							"TXTexample@test.com",
+						},
+						Errors: []string{
+							"Sample TXT error message",
+						},
+					},
+					CAA: CAAResults{
+						Emails: []string{
+							"CAAexample@test.com",
+						},
+						Errors: []string{
+							"Sample CAA error message",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Response received with records for TXT only",
+			apiResponse: mockResponseTXTOnly,
+
+			expectedResponse: AuthorisedEmails{
+				Constructed: []string{
+					"admin@test.com",
+					"administrator@test.com",
+					"webmaster@test.com",
+					"hostmaster@test.com",
+					"postmaster@test.com",
+				},
+				DNS: DNSResults{
+					SOA: SOAResults{
+						Emails: []string{},
+					},
+					TXT: TXTResults{
+						Emails: []string{
+							"TXTexample@test.com",
+						},
+					},
+					CAA: CAAResults{
+						Emails: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		var tc = tc
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(tc.apiResponse))
+		}))
+		defer testServer.Close()
+
+		var ctx, cancel = context.WithCancel(context.Background())
+		defer cancel()
+
+		var conf *Config = &Config{
+			URL:       testServer.URL,
+			APIKey:    "1234",
+			APISecret: "abcdefgh",
+			TLSKey:    testhelpers.MustGetPrivateKeyFromFile(t, "testdata/rsa_priv.key"),
+			TLSCert:   testhelpers.MustGetCertFromFile(t, "testdata/tls.cert"),
+		}
+
+		client, err := NewClient(ctx, conf)
+		if err != nil {
+			t.Errorf("error creating client: %v", err)
+		}
+
+		response, err := client.ClaimEmailRetrieve(ctx, "abcd1234")
+		if !reflect.DeepEqual(*response, tc.expectedResponse) {
+			t.Errorf("expected response not received, got %v, want %v", *response, tc.expectedResponse)
+		}
+	}
+}

--- a/client_api_test.go
+++ b/client_api_test.go
@@ -51,25 +51,25 @@ var mockResponseWithErrors string = `{
 				"emails": [
 					"SOAexample@test.com"
 				],
-        "errors": [
-          "Sample SOA error message"
-        ]
+				"errors": [
+					"Sample SOA error message"
+				]
 			},
 			"TXT": {
 				"emails": [
 					"TXTexample@test.com"
 				],
-        "errors": [
-          "Sample TXT error message"
-        ]
+				"errors": [
+					"Sample TXT error message"
+				]
 			},
 			"CAA": {
 				"emails": [
 					"CAAexample@test.com"
 				],
-        "errors": [
-          "Sample CAA error message"
-        ]
+				"errors": [
+					"Sample CAA error message"
+				]
 			}
 		}
 	}`
@@ -83,17 +83,17 @@ var mockResponseTXTOnly string = `{
 			"postmaster@test.com"
 		],
 		"dns": {
-      "SOA": {
-        "emails": []
-      },
+			"SOA": {
+				"emails": []
+			},
 			"TXT": {
 				"emails": [
 					"TXTexample@test.com"
 				]
 			},
-      "CAA": {
-        "emails": []
-      }
+			"CAA": {
+				"emails": []
+			}
 		}
 	}`
 

--- a/client_relogin_test.go
+++ b/client_relogin_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*
@@ -62,7 +63,7 @@ func TestRelogin(t *testing.T) {
 		t.Fatalf("failed to create new client from file: %v", err)
 	}
 
-	var oldToken = clnt.tokenRead()
+	var oldToken = clnt.GetToken()
 
 	if _, err = clnt.Policy(ctx); err != nil {
 		t.Fatalf("couldn't get response: %v", err)
@@ -76,7 +77,7 @@ func TestRelogin(t *testing.T) {
 		t.Fatalf("couldn't get response: %v", err)
 	}
 
-	var newToken = clnt.tokenRead()
+	var newToken = clnt.GetToken()
 
 	if oldToken == newToken {
 		t.Errorf("old and new tokens unexpectedly compare equal")
@@ -87,13 +88,13 @@ func TestRelogin(t *testing.T) {
 	// a new token is automatically obtained.
 	oldToken = newToken
 
-	clnt.tokenSet(expiredToken)
+	clnt.SetToken(expiredToken)
 
 	if _, err = clnt.Policy(ctx); err != nil {
 		t.Fatalf("couldn't get response: %v", err)
 	}
 
-	newToken = clnt.tokenRead()
+	newToken = clnt.GetToken()
 
 	if oldToken == newToken {
 		t.Errorf("old and new tokens unexpectedly compare equal")

--- a/cmd/hvclient/claims.go
+++ b/cmd/hvclient/claims.go
@@ -154,8 +154,12 @@ func claimEmailRetrieve(clnt *hvclient.Client, id, emailAddress string) {
 	}
 
 	fmt.Printf("Constructed: %v\n", authorisedEmails.Constructed)
-	fmt.Printf("DNS: %v\n", authorisedEmails.DNS.SOA.Emails)
-	fmt.Printf("Errors: %v\n", authorisedEmails.DNS.SOA.Errors)
+	fmt.Printf("DNS SOA: %v\n", authorisedEmails.DNS.SOA.Emails)
+	fmt.Printf("Errors SOA: %v\n", authorisedEmails.DNS.SOA.Errors)
+	fmt.Printf("DNS TXT: %v\n", authorisedEmails.DNS.TXT.Emails)
+	fmt.Printf("Errors TXT: %v\n", authorisedEmails.DNS.TXT.Errors)
+	fmt.Printf("DNS CAA: %v\n", authorisedEmails.DNS.CAA.Emails)
+	fmt.Printf("Errors CAA: %v\n", authorisedEmails.DNS.CAA.Errors)
 }
 
 // claimReassert reasserts an existing domain claim with the specified


### PR DESCRIPTION
When using HVClient to retrieve the list of email addresses authorized to perform email validation for a claim submission only the SOA results were being returned and not TXT or CAA records.

Updates made so that TXT and CAA records are now returned by HVClient.

Update also made to replace old method names that were being used in a test file with the updated names that were done as part of a previous change.